### PR TITLE
Add Streamlit Black-Scholes option pricing app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Martingale
+
+A minimal repository containing examples, including a Streamlit app to price European options using the Black-Scholes formula.
+
+## Black-Scholes Streamlit App
+
+Run the app with:
+
+```bash
+streamlit run black_scholes_app.py
+```
+
+The app lets you input the underlying price, strike, time to maturity, risk-free rate and volatility, then displays the corresponding call or put option price.

--- a/black_scholes_app.py
+++ b/black_scholes_app.py
@@ -1,0 +1,41 @@
+import math
+import streamlit as st
+
+
+def norm_cdf(x: float) -> float:
+    """Cumulative distribution function for the standard normal distribution."""
+    return 0.5 * (1.0 + math.erf(x / math.sqrt(2.0)))
+
+
+def black_scholes_price(
+    s: float, k: float, t: float, r: float, sigma: float, option_type: str = "call"
+) -> float:
+    """Calculate European option price using the Black-Scholes formula."""
+    if t <= 0 or sigma <= 0:
+        raise ValueError("Time to maturity and volatility must be positive")
+
+    d1 = (math.log(s / k) + (r + 0.5 * sigma ** 2) * t) / (sigma * math.sqrt(t))
+    d2 = d1 - sigma * math.sqrt(t)
+
+    if option_type == "call":
+        price = s * norm_cdf(d1) - k * math.exp(-r * t) * norm_cdf(d2)
+    else:
+        price = k * math.exp(-r * t) * norm_cdf(-d2) - s * norm_cdf(-d1)
+    return price
+
+
+st.title("Black-Scholes Option Pricer")
+
+s = st.number_input("Underlying price", value=100.0)
+k = st.number_input("Strike price", value=100.0)
+t = st.number_input("Time to maturity (years)", value=1.0)
+r = st.number_input("Risk-free rate", value=0.01)
+sigma = st.number_input("Volatility", value=0.2)
+option_type = st.selectbox("Option type", ["call", "put"])
+
+if st.button("Calculate"):
+    try:
+        price = black_scholes_price(s, k, t, r, sigma, option_type)
+        st.write(f"{option_type.capitalize()} option price: {price:.4f}")
+    except ValueError as e:
+        st.error(str(e))


### PR DESCRIPTION
## Summary
- Add Streamlit app to compute European option prices via Black-Scholes formula.
- Update README with usage instructions.

## Testing
- `python -m py_compile hello.py black_scholes_app.py`
- `python black_scholes_app.py` (fails: ModuleNotFoundError: No module named 'streamlit')
- `pip install streamlit` (fails: Could not connect to proxy, 403 Forbidden)

------
https://chatgpt.com/codex/tasks/task_e_68bdd6564b5c832b847f9fd46000f575