### PR TITLE
Add pytest tests and CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+            python-version: '3.x'
+      - name: Install dependencies
+        run: |
+            pip install .[test]
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.venv/

--- a/black_scholes.py
+++ b/black_scholes.py
@@ -1,0 +1,23 @@
+import math
+
+
+def norm_cdf(x: float) -> float:
+    """Cumulative distribution function for the standard normal distribution."""
+    return 0.5 * (1.0 + math.erf(x / math.sqrt(2.0)))
+
+
+def black_scholes_price(
+    s: float, k: float, t: float, r: float, sigma: float, option_type: str = "call",
+) -> float:
+    """Calculate European option price using the Black-Scholes formula."""
+    if t <= 0 or sigma <= 0:
+        raise ValueError("Time to maturity and volatility must be positive")
+
+    d1 = (math.log(s / k) + (r + 0.5 * sigma ** 2) * t) / (sigma * math.sqrt(t))
+    d2 = d1 - sigma * math.sqrt(t)
+
+    if option_type == "call":
+        price = s * norm_cdf(d1) - k * math.exp(-r * t) * norm_cdf(d2)
+    else:
+        price = k * math.exp(-r * t) * norm_cdf(-d2) - s * norm_cdf(-d1)
+    return price

--- a/black_scholes_app.py
+++ b/black_scholes_app.py
@@ -1,41 +1,24 @@
-import math
 import streamlit as st
+from black_scholes import black_scholes_price
 
 
-def norm_cdf(x: float) -> float:
-    """Cumulative distribution function for the standard normal distribution."""
-    return 0.5 * (1.0 + math.erf(x / math.sqrt(2.0)))
+def main() -> None:
+    st.title("Black-Scholes Option Pricer")
+
+    s = st.number_input("Underlying price", value=100.0)
+    k = st.number_input("Strike price", value=100.0)
+    t = st.number_input("Time to maturity (years)", value=1.0)
+    r = st.number_input("Risk-free rate", value=0.01)
+    sigma = st.number_input("Volatility", value=0.2)
+    option_type = st.selectbox("Option type", ["call", "put"])
+
+    if st.button("Calculate"):
+        try:
+            price = black_scholes_price(s, k, t, r, sigma, option_type)
+            st.write(f"{option_type.capitalize()} option price: {price:.4f}")
+        except ValueError as e:
+            st.error(str(e))
 
 
-def black_scholes_price(
-    s: float, k: float, t: float, r: float, sigma: float, option_type: str = "call"
-) -> float:
-    """Calculate European option price using the Black-Scholes formula."""
-    if t <= 0 or sigma <= 0:
-        raise ValueError("Time to maturity and volatility must be positive")
-
-    d1 = (math.log(s / k) + (r + 0.5 * sigma ** 2) * t) / (sigma * math.sqrt(t))
-    d2 = d1 - sigma * math.sqrt(t)
-
-    if option_type == "call":
-        price = s * norm_cdf(d1) - k * math.exp(-r * t) * norm_cdf(d2)
-    else:
-        price = k * math.exp(-r * t) * norm_cdf(-d2) - s * norm_cdf(-d1)
-    return price
-
-
-st.title("Black-Scholes Option Pricer")
-
-s = st.number_input("Underlying price", value=100.0)
-k = st.number_input("Strike price", value=100.0)
-t = st.number_input("Time to maturity (years)", value=1.0)
-r = st.number_input("Risk-free rate", value=0.01)
-sigma = st.number_input("Volatility", value=0.2)
-option_type = st.selectbox("Option type", ["call", "put"])
-
-if st.button("Calculate"):
-    try:
-        price = black_scholes_price(s, k, t, r, sigma, option_type)
-        st.write(f"{option_type.capitalize()} option price: {price:.4f}")
-    except ValueError as e:
-        st.error(str(e))
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,6 @@ requires-python = ">=3.12"
 dependencies = [
     "streamlit>=1.49.1",
 ]
+
+[project.optional-dependencies]
+test = ["pytest>=7.4"]

--- a/tests/test_black_scholes.py
+++ b/tests/test_black_scholes.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from black_scholes import black_scholes_price
+
+
+def test_black_scholes_call_price():
+    price = black_scholes_price(100, 100, 1, 0.01, 0.2, "call")
+    assert price == pytest.approx(8.4333, rel=1e-4)
+
+
+def test_black_scholes_put_price():
+    price = black_scholes_price(100, 100, 1, 0.01, 0.2, "put")
+    assert price == pytest.approx(7.4383, rel=1e-4)
+
+
+def test_black_scholes_invalid_params():
+    with pytest.raises(ValueError):
+        black_scholes_price(100, 100, 0, 0.01, 0.2)


### PR DESCRIPTION
## Summary
- Extract Black-Scholes option pricing logic into standalone module
- Add pytest suite covering pricing results and error handling
- Configure GitHub Actions to run tests on pushes and pull requests to main

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bdd9307710832b95e004e614976f4b